### PR TITLE
Adds ability to auto approve and merge Dependabot PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,19 @@
+pull_request_rules:
+  - name: automatic approve dependabot pull requests
+    conditions:
+      - author~=dependabot\[bot\]|dependabot-preview\[bot\]
+      - status-success=continuous-integration/appveyor/branch
+      - status-success=continuous-integration/appveyor/pr
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success=continuous-integration/travis-ci/push
+    actions:
+      review:
+        type: APPROVE
+
+  - name: automatic merge for dependabot pull requests
+    conditions:
+      - author~=dependabot\[bot\]|dependabot-preview\[bot\]
+      - "#approved-reviews-by>=1"
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #0000

Changes proposed in this pull request:

* Auto-approve and auto-merge dependabots prs

Output from Pytest:

```
================================================= test session starts ==================================================
platform darwin -- Python 3.7.2, pytest-4.1.0, py-1.7.0, pluggy-0.8.1
rootdir: /Users/jackhuman/dev/satsuki, inifile: setup.cfg
collected 10 items                                                                                                     

tests/test_satsuki.py ..........                                                                                  [100%]

============================================== 10 passed in 6.50 seconds ===============================================

```
